### PR TITLE
Readme: Fix markdown display error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,8 @@
 
 p5.bots is a library to facilitate communication between [p5.js](http://p5js.org/) running in your browser and a microcontroller* running [Firmata](https://github.com/firmata/arduino)**.
 
-<small>
-```
-* The library has been tested on Arduino Unos, but should work on anything running Firmata.  
-** The serial API does not depend on Firmata.
-```
-</small>
+> \* The library has been tested on Arduino Unos, but should work on anything running Firmata.  
+> \** The serial API does not depend on Firmata.
 
 To do this, it uses the `socket.io` library and `node.js` to send messages between the two devices, in a language each device can understand.
 


### PR DESCRIPTION
Change <small> tags (which was displayed wrong) to markdown cites.

From:
```
* The library has been tested on Arduino Unos, but should work on anything running Firmata.  
** The serial API does not depend on Firmata.
```
(seems like pull requests display this markdown correctly unlike default view of readme.md. Go ahead and check that file)    

To:
> \* The library has been tested on Arduino Unos, but should work on anything running Firmata. 
> \** The serial API does not depend on Firmata.
